### PR TITLE
Add note on method order to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ class Example extends Resource
 }
 ```
 
+Generally, `attach()` should be the last method you call on the field as it may rely on properties set by earlier calls. For example you will get validation failures if `nullable()` is called after `attach()`.
+
 If you use [datomatic/laravel-enum-helper](https://github.com/datomatic/laravel-enum-helper) you can set optionally a custom dynamic property or/and a subset of cases.  
 The default property is `description`.
 ```php

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ class Example extends Resource
 }
 ```
 
-Generally, `attach()` should be the last method you call on the field as it may rely on properties set by earlier calls. For example you will get validation failures if `nullable()` is called after `attach()`.
+Be aware that order in which methods on the field are called can be sigificant. For example `nullable()` must be called before *before* `attach()`, and `options()` must be called *after* `attach()`.
 
 If you use [datomatic/laravel-enum-helper](https://github.com/datomatic/laravel-enum-helper) you can set optionally a custom dynamic property or/and a subset of cases.  
 The default property is `description`.


### PR DESCRIPTION
This documents a problem I've run into repeatedly, and I finally figured out the cause, specifically in the case of `nullable`. Because the `nullable` property is used in `attach` to add a `nullable` validation rule, the validation will fail if `nullable()` has not been called before `attach`. Looking at the code in `attach`, it's likely this applies to other methods such as `options`, so this PR just adds a note to the readme to provide a pointer for similar issues.