### PR TITLE
fix/field-resolve-error: fix error exception for non BackedEnum when n…

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -19,7 +19,10 @@ class Enum extends Select
         parent::__construct($name, $attribute, $resolveCallback);
         $this->resolveUsing(
             function ($value) {
-                return $value instanceof UnitEnum ? $value->value : $value;
+                if($value instanceof BackedEnum){
+                    return $value->value;
+                }
+                return $value instanceof UnitEnum ? $value->name : $value;
             }
         );
 


### PR DESCRIPTION
ErrorException when nova update-fields request for simple UnitEnum (not BackedEnum):
Undefined property: App\\Enums\\Status::$value